### PR TITLE
Remove PyGIWarning message

### DIFF
--- a/scripts/build_error.py
+++ b/scripts/build_error.py
@@ -4,6 +4,7 @@ import os.path
 import os
 os.environ['NO_AT_BRIDGE'] = '0'
 
+gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk        # pylint:disable=no-name-in-module
 
 


### PR DESCRIPTION
After getting an error, it's displayed the following warning:

Gtk was imported without specifying a version first.
Use gi.require_version('Gtk', '3.0') before import to ensure
that the right version gets loaded.

This fix tries to remove this message.
