### PR TITLE
Add -n flag to unset DISPLAY

### DIFF
--- a/lpf.1
+++ b/lpf.1
@@ -3,7 +3,7 @@
 lpf \- Build non-redistributable rpms
 
 .SH SYNOPSIS
-.B lpf <command> [options]
+.B lpf [-n] <command> [options]
 
 .SH DESCRIPTION
 Builds and installs non-redistributable rpms by downloading binaries,
@@ -30,7 +30,7 @@ below.
 .PP
 If DISPLAY is defined in the environment, lpf uses GUI dialogs for user
 interaction even when invoked from command line. To force CLI only
-operation, unset DISPLAY.
+operation, use the -n flag or unset DISPLAY.
 .PP
 lpf has a notification system for packages needing to be updated. See
 NOTIFICATIONS below.
@@ -157,4 +157,3 @@ sudo(8)
 .TP
 pkexec(1)
     Used to add user to pkg-build group at initial run.
-

--- a/scripts/lpf
+++ b/scripts/lpf
@@ -10,7 +10,7 @@ source $scriptdir/lpf-defs.bash
 function usage()
 {
     cat << EOF
-Usage: lpf <command> [args]
+Usage: lpf [-n] <command> [args]
 
 commands:
     list        List all packages.
@@ -41,8 +41,8 @@ commands:
                 Re-enable notification messages for a possibly muted package.
 
 
-Unset \$DISPLAY to disable GUI dialogs. See the manpage for more commands
-and other info.
+Use the -n flag or unset \$DISPLAY to disable GUI dialogs. See the manpage for
+more commands and other info.
 EOF
 }
 
@@ -230,6 +230,17 @@ export NO_AT_BRIDGE=0
 
 export SUDO_ASKPASS=$scriptdir/sudo_askpass
 
+# parse basic flags with getopts
+while getopts "hn" opt; do
+  # shellcheck disable=2220
+  case $opt in
+    h) usage; exit;;
+    n) unset DISPLAY;;
+  esac
+done
+shift "$((OPTIND-1))"
+
+# now fall through to command parsing
 command=$1
 shift
 case $command in


### PR DESCRIPTION
I found the whole behavior about unsetting `DISPLAY` to disable GUI dialogs to be really confusing, since I can't think of any other Unix CLI programs that automatically pop up GUI dialogs this way. The lpf usage documents the behavior, but for some reason by brain looks to the top of the command synopsis/usage first when looking for how to change program behavior, and it took me way too long to see the note about unsetting `DISPLAY` at the bottom of the usage string.

This change uses the Bash `getopts` builtin to:
 * Add a `-n` flag that automatically unsets `DISPLAY`
 * Invoking with `-h` will show usage and exit (as is currently the case), but now the exit code in this situation will now 0.

After parsing `-h` or `-n` the getopts code will shift the arguments and fall through to the existing command parsing code. I also updated the man page and usage string.

Note that this uses the `getopts` shell builtin, **not** the external `getopt` command, so this change does not introduce any additional dependencies as it uses a feature already built into Bash itself. Maybe the lack of `getopts` in lpf is an intentional style choice, so take this as you will, but I consider this to be more Unixy and intuitive.